### PR TITLE
left justify article text

### DIFF
--- a/src/components/heading.js
+++ b/src/components/heading.js
@@ -1,6 +1,6 @@
 import { h } from "preact";
 
-export default ({ as = "h1", children }) => {
+export default ({ as = "h1", classAdd = "", children }) => {
   const Component = as;
   const weight = (c) => {
     switch (c) {
@@ -16,7 +16,9 @@ export default ({ as = "h1", children }) => {
   };
   return (
     <Component
-      class={`${weight(as)} text-primary-900 dark:text-primary-50 max-w-2xl`}
+      class={`${weight(as)} text-primary-900 dark:text-primary-50${
+        classAdd.length > 0 ? ` ${classAdd}` : ""
+      }`}
     >
       {children}
     </Component>

--- a/src/components/text.js
+++ b/src/components/text.js
@@ -4,7 +4,7 @@ export default ({ as = "p", classAdd = "", children }) => {
   const Component = as;
   return (
     <Component
-      class={`text-xl md:text-lg lg:text-base text-primary-900 dark:text-primary-50 max-w-prose${
+      class={`text-xl md:text-lg lg:text-base text-primary-900 dark:text-primary-50${
         classAdd.length > 0 ? ` ${classAdd}` : ""
       }`}
     >

--- a/src/page-wrapper.js
+++ b/src/page-wrapper.js
@@ -14,27 +14,51 @@ import ArticleWrapper from "./components/wrapperArticle.js";
 
 const components = {
   p: ({ children }) => (
-    <Text as="p" classAdd="px-2 sm:w-3/4 md:w-2/3 lg:w-1/2">
+    <Text as="p" classAdd="px-2 w-full md:w-3/4 lg:w-2/3 xl:w-1/2">
       {children}
     </Text>
   ),
   h1: (props) => (
-    <Heading as="h1" {...props} classAdd="px-2 sm:w-3/4 md:w-2/3 lg:w-1/2" />
+    <Heading
+      as="h1"
+      {...props}
+      classAdd="px-2 w-full md:w-3/4 lg:w-2/3 xl:w-1/2"
+    />
   ),
   h2: (props) => (
-    <Heading as="h2" {...props} classAdd="px-2 sm:w-3/4 md:w-2/3 lg:w-1/2" />
+    <Heading
+      as="h2"
+      {...props}
+      classAdd="px-2 w-full md:w-3/4 lg:w-2/3 xl:w-1/2"
+    />
   ),
   h3: (props) => (
-    <Heading as="h3" {...props} classAdd="px-2 sm:w-3/4 md:w-2/3 lg:w-1/2" />
+    <Heading
+      as="h3"
+      {...props}
+      classAdd="px-2 w-full md:w-3/4 lg:w-2/3 xl:w-1/2"
+    />
   ),
   h4: (props) => (
-    <Heading as="h4" {...props} classAdd="px-2 sm:w-3/4 md:w-2/3 lg:w-1/2" />
+    <Heading
+      as="h4"
+      {...props}
+      classAdd="px-2 w-full md:w-3/4 lg:w-2/3 xl:w-1/2"
+    />
   ),
   h5: (props) => (
-    <Heading as="h5" {...props} classAdd="px-2 sm:w-3/4 md:w-2/3 lg:w-1/2" />
+    <Heading
+      as="h5"
+      {...props}
+      classAdd="px-2 w-full md:w-3/4 lg:w-2/3 xl:w-1/2"
+    />
   ),
   h6: (props) => (
-    <Heading as="h6" {...props} classAdd="px-2 sm:w-3/4 md:w-2/3 lg:w-1/2" />
+    <Heading
+      as="h6"
+      {...props}
+      classAdd="px-2 w-full md:w-3/4 lg:w-2/3 xl:w-1/2"
+    />
   ),
   blockquote: ({ children }) => (
     <blockquote class="max-w-prose">{children}</blockquote>

--- a/src/page-wrapper.js
+++ b/src/page-wrapper.js
@@ -93,7 +93,7 @@ const components = {
   codeblock: (props) => (
     <div class="bg-gray-900 dark:bg-gray-900 w-full mb-4 overflow-x-auto">
       <div class="grid justify-items-center">
-        <div class="py-3 px-2 sm:w-3/4 md:w-2/3 lg:w-1/2">
+        <div class="py-3 px-2 w-full md:w-3/4 lg:w-2/3 xl:w-1/2">
           <div {...props} />
         </div>
       </div>

--- a/src/page-wrapper.js
+++ b/src/page-wrapper.js
@@ -14,16 +14,28 @@ import ArticleWrapper from "./components/wrapperArticle.js";
 
 const components = {
   p: ({ children }) => (
-    <Text as="p" classAdd="px-2 mx-auto">
+    <Text as="p" classAdd="px-2 sm:w-3/4 md:w-2/3 lg:w-1/2">
       {children}
     </Text>
   ),
-  h1: (props) => <Heading as="h1" {...props} />,
-  h2: (props) => <Heading as="h2" {...props} />,
-  h3: (props) => <Heading as="h3" {...props} />,
-  h4: (props) => <Heading as="h4" {...props} />,
-  h5: (props) => <Heading as="h5" {...props} />,
-  h6: (props) => <Heading as="h6" {...props} />,
+  h1: (props) => (
+    <Heading as="h1" {...props} classAdd="px-2 sm:w-3/4 md:w-2/3 lg:w-1/2" />
+  ),
+  h2: (props) => (
+    <Heading as="h2" {...props} classAdd="px-2 sm:w-3/4 md:w-2/3 lg:w-1/2" />
+  ),
+  h3: (props) => (
+    <Heading as="h3" {...props} classAdd="px-2 sm:w-3/4 md:w-2/3 lg:w-1/2" />
+  ),
+  h4: (props) => (
+    <Heading as="h4" {...props} classAdd="px-2 sm:w-3/4 md:w-2/3 lg:w-1/2" />
+  ),
+  h5: (props) => (
+    <Heading as="h5" {...props} classAdd="px-2 sm:w-3/4 md:w-2/3 lg:w-1/2" />
+  ),
+  h6: (props) => (
+    <Heading as="h6" {...props} classAdd="px-2 sm:w-3/4 md:w-2/3 lg:w-1/2" />
+  ),
   blockquote: ({ children }) => (
     <blockquote class="max-w-prose">{children}</blockquote>
   ),
@@ -42,9 +54,7 @@ const components = {
       {children}
     </List>
   ),
-  table: ({ children }) => (
-    <table class="table-auto max-w-prose">{children}</table>
-  ),
+  table: ({ children }) => <table class="table-auto">{children}</table>,
   thead: ({ children }) => <thead>{children}</thead>,
   tbody: ({ children }) => <tbody>{children}</tbody>,
   tr: ({ children }) => <tr>{children}</tr>,
@@ -58,8 +68,10 @@ const components = {
   a: ({ children, ...rest }) => <Link {...rest}>{children}</Link>,
   codeblock: (props) => (
     <div class="bg-gray-900 dark:bg-gray-900 w-full mb-4 overflow-x-auto">
-      <div class="mx-auto py-3 px-8 max-w-5xl">
-        <div {...props} />
+      <div class="grid justify-items-center">
+        <div class="py-3 px-2 sm:w-3/4 md:w-2/3 lg:w-1/2">
+          <div {...props} />
+        </div>
       </div>
     </div>
   ),


### PR DESCRIPTION
## Motivation

The article text was center justified as a bandaid, and it's time to take care of it. It should be left justified in a smaller than full width column.
